### PR TITLE
use image scale in context

### DIFF
--- a/Chats/Chats/MessageBubbleCell.swift
+++ b/Chats/Chats/MessageBubbleCell.swift
@@ -101,7 +101,7 @@ func bubbleImageMake() -> (incoming: UIImage, incomingHighlighed: UIImage, outgo
 
 func coloredImage(image: UIImage, red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> UIImage! {
     let rect = CGRect(origin: CGPointZero, size: image.size)
-    UIGraphicsBeginImageContext(image.size)
+    UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
     let context = UIGraphicsGetCurrentContext()
     image.drawInRect(rect)
     CGContextSetRGBFillColor(context, red, green, blue, alpha)


### PR DESCRIPTION
This fixes the blurry message bubbles.

Old:

![screen shot 2014-09-17 at 2 27 43 pm](https://cloud.githubusercontent.com/assets/31402/4311733/b70d439a-3eb1-11e4-9845-5a9d978b9afd.png)

New:

![screen shot 2014-09-17 at 2 28 15 pm](https://cloud.githubusercontent.com/assets/31402/4311734/bbb93624-3eb1-11e4-8857-415650539ce3.png)
